### PR TITLE
Use Cartesian impedance mode for Cartesian control

### DIFF
--- a/franka_hardware/src/robot.cpp
+++ b/franka_hardware/src/robot.cpp
@@ -334,11 +334,11 @@ void Robot::initializeJointPositionInterface() {
 void Robot::initializeCartesianVelocityInterface() {
   try {
     active_control_ = robot_->startCartesianVelocityControl(
-        research_interface::robot::Move::ControllerMode::kJointImpedance);
+        research_interface::robot::Move::ControllerMode::kCartesianImpedance);
   } catch (const franka::ControlException& e) {
     robot_->automaticErrorRecovery();
     active_control_ = robot_->startCartesianVelocityControl(
-        research_interface::robot::Move::ControllerMode::kJointImpedance);
+        research_interface::robot::Move::ControllerMode::kCartesianImpedance);
   }
   cartesian_velocity_interface_active_ = true;
 }
@@ -346,11 +346,11 @@ void Robot::initializeCartesianVelocityInterface() {
 void Robot::initializeCartesianPoseInterface() {
   try {
     active_control_ = robot_->startCartesianPoseControl(
-        research_interface::robot::Move::ControllerMode::kJointImpedance);
+        research_interface::robot::Move::ControllerMode::kCartesianImpedance);
   } catch (const franka::ControlException& e) {
     robot_->automaticErrorRecovery();
     active_control_ = robot_->startCartesianPoseControl(
-        research_interface::robot::Move::ControllerMode::kJointImpedance);
+        research_interface::robot::Move::ControllerMode::kCartesianImpedance);
   }
   cartesian_pose_interface_active_ = true;
 }

--- a/franka_hardware/test/franka_robot_test.cpp
+++ b/franka_hardware/test/franka_robot_test.cpp
@@ -27,7 +27,10 @@ TEST_F(FrankaRobotTests,
 
 TEST_F(FrankaRobotTests,
        whenInitializeCartesianVelocityInterfaceCalled_thenStartCartesianVelocityControl) {
-  EXPECT_CALL(*mock_libfranka_robot, startCartesianVelocityControl(testing::_)).Times(1);
+  EXPECT_CALL(*mock_libfranka_robot,
+              startCartesianVelocityControl(
+                  research_interface::robot::Move::ControllerMode::kCartesianImpedance))
+      .Times(1);
 
   franka_hardware::Robot robot(std::move(mock_libfranka_robot), std::move(mock_model));
 
@@ -35,7 +38,10 @@ TEST_F(FrankaRobotTests,
 }
 
 TEST_F(FrankaRobotTests, whenInitializeCartesianPoseInterfaceCalled_thenStartCartesianPoseControl) {
-  EXPECT_CALL(*mock_libfranka_robot, startCartesianPoseControl(testing::_)).Times(1);
+  EXPECT_CALL(*mock_libfranka_robot,
+              startCartesianPoseControl(
+                  research_interface::robot::Move::ControllerMode::kCartesianImpedance))
+      .Times(1);
 
   franka_hardware::Robot robot(std::move(mock_libfranka_robot), std::move(mock_model));
 


### PR DESCRIPTION
## Summary

- start Cartesian velocity control in kCartesianImpedance mode
- start Cartesian pose control in kCartesianImpedance mode
- verify both Cartesian interfaces request the Cartesian impedance controller mode

This makes stiffness values set through SetCartesianStiffness effective for Cartesian command interfaces. Joint position and joint velocity control continue to use kJointImpedance.

Closes #53.

## Testing

- git diff --check
- static verification of all initial and automatic-recovery controller-mode paths
- full ROS 2/libfranka build deferred to repository CI because those dependencies are not available in the local macOS environment