### PR TITLE
Update clone command to use 'jazzy' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For detailed instructions on preparing VS Code to use `.devcontainer`, follow th
 
 1. **Clone the Repositories:**
     ```bash
-    git clone https://github.com/frankarobotics/franka_ros2.git
+    git clone -b jazzy https://github.com/frankarobotics/franka_ros2.git
     cd franka_ros2
     ```
     We provide separate instructions for using Docker from the command line or


### PR DESCRIPTION
Correct cloning of repository to explicitly pull from the `jazzy` branch in Docker installation steps.