### PR TITLE
Size and label the FrankaRobotState joint arrays from this broadcaster's own arm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog for package franka_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+UNRELEASED
+----------
+Requires libfranka >= 0.20.4 and franka_description >= 2.9.0 requires ROS 2 Jazzy
+
+* fix: ``franka_semantic_components::FrankaRobotState`` now sizes and labels the joint arrays of
+  ``FrankaRobotState`` from the arm the component is bound to, instead of from every revolute
+  joint in the global ``robot_description``. With more than seven revolute joints in the
+  description the arrays came out longer than seven, and the trailing entries were filled by
+  reading past the end of libfranka's seven-element arrays, so they carried a different quantity
+  than their joint name promised and each broadcaster labelled its own arm's data with another
+  arm's joint names.
+
 v3.5.2 (2026-08-17)
 -------------------
 Requires libfranka >= 0.20.4 and franka_description >= 2.9.0 requires ROS 2 Jazzy

--- a/franka_robot_state_broadcaster/test/test_franka_robot_state_broadcaster.cpp
+++ b/franka_robot_state_broadcaster/test/test_franka_robot_state_broadcaster.cpp
@@ -14,6 +14,8 @@
 
 #include <gmock/gmock.h>
 
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -37,13 +39,31 @@ class MockFrankaRobotState : public franka_semantic_components::FrankaRobotState
   MOCK_METHOD(bool, get_values_as_message, (franka_msgs::msg::FrankaRobotState&), (override));
 };
 
+// FrankaRobotState resolves its own arm's seven joints out of the description, so the mock needs
+// a description that names them. ros2_control_test_assets' minimal robot does not.
+inline std::string singleArmUrdf(const std::string& arm_name) {
+  std::stringstream urdf;
+  urdf << "<?xml version=\"1.0\"?><robot name=\"" << arm_name << "\">";
+  urdf << "<link name=\"" << arm_name << "_link0\"/>";
+  for (size_t joint = 1; joint <= 7; ++joint) {
+    urdf << "<link name=\"" << arm_name << "_link" << joint << "\"/>"
+         << "<joint name=\"" << arm_name << "_joint" << joint << "\" type=\"revolute\">"
+         << "<parent link=\"" << arm_name << "_link" << joint - 1 << "\"/>"
+         << "<child link=\"" << arm_name << "_link" << joint << "\"/>"
+         << "<axis xyz=\"0 0 1\"/>"
+         << "<limit lower=\"-2.0\" upper=\"2.0\" effort=\"87.0\" velocity=\"2.0\"/></joint>";
+  }
+  urdf << "</robot>";
+  return urdf.str();
+}
+
 using namespace franka_robot_state_broadcaster;
 class TestFrankaRobotStateBroadcaster : public ::testing::Test {
  protected:
   void SetUp() override {
     std::unique_ptr<MockFrankaRobotState> franka_robot_state =
         std::make_unique<MockFrankaRobotState>("mock_franka_robot_state",
-                                               ros2_control_test_assets::minimal_robot_urdf);
+                                               singleArmUrdf("mock_franka_robot_state"));
     franka_robot_state_raw_ = franka_robot_state.get();  // Save raw pointer for mocking
 
     broadcaster_ = std::make_unique<FrankaRobotStateBroadcaster>(std::move(franka_robot_state));

--- a/franka_semantic_components/include/franka_semantic_components/franka_robot_state.hpp
+++ b/franka_semantic_components/include/franka_semantic_components/franka_robot_state.hpp
@@ -100,8 +100,10 @@ class FrankaRobotState
   auto set_links_from_urdf() -> void;
 
   /**
-   * @brief Populate the joint_name std::vector with the joints from urdf object in order.
+   * @brief Populate the joint_name std::vector with this arm's seven joints, in joint order.
    *
+   * The robot_description may describe more than one arm; only the joints belonging to this
+   * component's arm are published. Throws std::runtime_error if one of them is missing.
    */
   auto set_joints_from_urdf() -> void;
 

--- a/franka_semantic_components/src/franka_robot_state.cpp
+++ b/franka_semantic_components/src/franka_robot_state.cpp
@@ -30,6 +30,9 @@ constexpr size_t kBaseLinkIndex = 0;
 constexpr size_t kFlangeLinkIndex = 8;
 constexpr size_t kLoadLinkIndex = 8;
 constexpr size_t kAccelerometerCount = 6;
+// libfranka reports exactly this many joints per arm; every std::array in
+// franka::RobotState that this component copies from is this wide.
+constexpr size_t kJointCount = 7;
 const std::string kTCPFrameName = "_hand_tcp";
 
 // franka::RobotMode and FrankaRobotState.robot_mode are intentionally isomorphic.
@@ -149,11 +152,18 @@ auto FrankaRobotState::set_links_from_urdf() -> void {
 }
 
 auto FrankaRobotState::set_joints_from_urdf() -> void {
-  auto& joints = model_->joints_;
-  for (const auto& [name, joint] : joints) {
-    if (joint->type == urdf::Joint::REVOLUTE) {
-      joint_names.push_back(name);
+  // This component is bound to a single arm's state interface, and libfranka reports exactly
+  // kJointCount values for that arm. The robot_description, however, is the controller
+  // manager's global one and may describe several arms, so it cannot be used to size or label
+  // the published arrays. Take this arm's joints by name, in joint order, the same way the
+  // accelerometer frames are resolved in initialize_robot_state_msg().
+  joint_names.reserve(kJointCount);
+  for (size_t i = 0; i < kJointCount; ++i) {
+    const auto joint_name = robot_name_ + "_joint" + std::to_string(i + 1);
+    if (model_->joints_.find(joint_name) == model_->joints_.end()) {
+      throw std::runtime_error("Joint '" + joint_name + "' not found in URDF.");
     }
+    joint_names.push_back(joint_name);
   }
 }
 

--- a/franka_semantic_components/test/franka_robot_state_test.cpp
+++ b/franka_semantic_components/test/franka_robot_state_test.cpp
@@ -241,3 +241,73 @@ TEST_F(FrankaRobotStateTest,
               bottom_readings[sensor][2]);
   }
 }
+
+void FrankaRobotStateMultiArmTest::TearDown() {
+  franka_state_friend.reset(nullptr);
+}
+
+void FrankaRobotStateMultiArmTest::SetUp() {
+  franka_state_friend = std::make_unique<FrankaRobotStateMultiArmTestFriend>(
+      robot_name + "/" + franka_state_interface_name);
+
+  robot_state.q = joint_angles;
+  robot_state.q_d = desired_joint_angles;
+  robot_state_box.set(robot_state);
+
+  hardware_interface::StateInterface franka_hw_state{
+      robot_name, franka_state_interface_name, reinterpret_cast<double*>(&robot_state_box_ptr)};
+  std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;
+
+  temp_state_interfaces.reserve(size);
+  temp_state_interfaces.emplace_back(franka_hw_state);
+
+  ASSERT_TRUE(franka_state_friend->assign_loaned_state_interfaces(temp_state_interfaces));
+  franka_state_friend->initialize_robot_state_msg(franka_robot_state_msg);
+  ASSERT_TRUE(franka_state_friend->get_values_as_message(franka_robot_state_msg));
+}
+
+// The robot_description holds fourteen revolute joints, but libfranka reports seven values for
+// the one arm this component is bound to. Sizing the arrays from the description made them
+// fourteen long and filled the extra entries by reading past the end of franka::RobotState's
+// seven-element arrays.
+TEST_F(FrankaRobotStateMultiArmTest, givenMultiArmRobotDescription_thenJointArraysAreArmLocal) {
+  const std::vector<std::string> expected_names = {"fr3_joint1", "fr3_joint2", "fr3_joint3",
+                                                   "fr3_joint4", "fr3_joint5", "fr3_joint6",
+                                                   "fr3_joint7"};
+
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_state.name, expected_names);
+  ASSERT_EQ(franka_robot_state_msg.desired_joint_state.name, expected_names);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_motor_state.name, expected_names);
+  ASSERT_EQ(franka_robot_state_msg.tau_ext_hat_filtered.name, expected_names);
+
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_state.position.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_state.velocity.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_state.effort.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.desired_joint_state.position.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.desired_joint_state.velocity.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.desired_joint_state.effort.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_motor_state.position.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_motor_state.velocity.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.measured_joint_motor_state.effort.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.tau_ext_hat_filtered.position.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.tau_ext_hat_filtered.velocity.size(), 7u);
+  ASSERT_EQ(franka_robot_state_msg.tau_ext_hat_filtered.effort.size(), 7u);
+}
+
+// Each entry has to carry the quantity its own field promises. Before the fix, entry seven of
+// measured_joint_state.position held q_d[0] rather than a measured position.
+TEST_F(FrankaRobotStateMultiArmTest, givenMultiArmRobotDescription_thenJointValuesAreNotMixed) {
+  ASSERT_THAT(joint_angles,
+              ::testing::ElementsAreArray(franka_robot_state_msg.measured_joint_state.position));
+  ASSERT_THAT(desired_joint_angles,
+              ::testing::ElementsAreArray(franka_robot_state_msg.desired_joint_state.position));
+}
+
+// A robot_description that does not describe this arm is a configuration error, not something to
+// publish around. initialize_robot_state_msg() already rejects a missing accelerometer frame the
+// same way.
+TEST(FrankaRobotStateStandaloneTest, givenDescriptionWithoutThisArm_thenConstructionThrows) {
+  EXPECT_THROW(franka_semantic_components::FrankaRobotState(
+                   "no_such_arm/robot_state", read_robot_description("franka_semantic_components")),
+               std::runtime_error);
+}

--- a/franka_semantic_components/test/franka_robot_state_test.hpp
+++ b/franka_semantic_components/test/franka_robot_state_test.hpp
@@ -26,6 +26,49 @@
 #include "franka_semantic_components/franka_robot_state.hpp"
 #include "gmock/gmock.h"
 
+inline std::string read_robot_description(const std::string& package_name) {
+  std::string package_path = ament_index_cpp::get_package_share_directory(package_name);
+  std::string file_path = package_path + "/robot_description_test.txt";
+
+  std::ifstream file(file_path);
+  if (!file) {
+    throw std::runtime_error("Failed to open file: " + file_path);
+  }
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+
+  return buffer.str();
+}
+
+// Splices a second seven-joint arm into a single-arm description, so that one robot_description
+// holds more than seven revolute joints - the shape a duo bringup hands to the controller
+// manager. The extra arm needs no accelerometer frames; only the arm under test is read out.
+inline std::string add_second_arm(const std::string& robot_description,
+                                  const std::string& arm_prefix,
+                                  const std::string& mount_link) {
+  std::stringstream arm;
+  arm << "<link name=\"" << arm_prefix << "_link0\"/>";
+  arm << "<joint name=\"" << arm_prefix << "_mount_joint\" type=\"fixed\">"
+      << "<parent link=\"" << mount_link << "\"/>"
+      << "<child link=\"" << arm_prefix << "_link0\"/></joint>";
+  for (size_t joint = 1; joint <= 7; ++joint) {
+    arm << "<link name=\"" << arm_prefix << "_link" << joint << "\"/>";
+    arm << "<joint name=\"" << arm_prefix << "_joint" << joint << "\" type=\"revolute\">"
+        << "<parent link=\"" << arm_prefix << "_link" << joint - 1 << "\"/>"
+        << "<child link=\"" << arm_prefix << "_link" << joint << "\"/>"
+        << "<axis xyz=\"0 0 1\"/>"
+        << "<limit lower=\"-2.0\" upper=\"2.0\" effort=\"87.0\" velocity=\"2.0\"/></joint>";
+  }
+
+  const auto closing_tag = robot_description.rfind("</robot>");
+  if (closing_tag == std::string::npos) {
+    throw std::runtime_error("robot_description has no closing </robot> tag.");
+  }
+  return robot_description.substr(0, closing_tag) + arm.str() +
+         robot_description.substr(closing_tag);
+}
+
 // implementing and friending so we can access member variables
 class FrankaRobotStateTestFriend : public franka_semantic_components::FrankaRobotState {
   FRIEND_TEST(FrankaRobotStateTest, validate_state_names_and_size);
@@ -39,25 +82,22 @@ class FrankaRobotStateTestFriend : public franka_semantic_components::FrankaRobo
   explicit FrankaRobotStateTestFriend(const std::string& name)
       : franka_semantic_components::FrankaRobotState(
             name,
-            get_robot_description("franka_semantic_components")) {}
+            read_robot_description("franka_semantic_components")) {}
 
   virtual ~FrankaRobotStateTestFriend() = default;
+};
 
- private:
-  static std::string get_robot_description(const std::string& package_name) {
-    std::string package_path = ament_index_cpp::get_package_share_directory(package_name);
-    std::string file_path = package_path + "/robot_description_test.txt";
+// Same component, but built from a robot_description that describes two arms.
+class FrankaRobotStateMultiArmTestFriend : public franka_semantic_components::FrankaRobotState {
+ public:
+  explicit FrankaRobotStateMultiArmTestFriend(const std::string& name)
+      : franka_semantic_components::FrankaRobotState(
+            name,
+            add_second_arm(read_robot_description("franka_semantic_components"),
+                           "second_fr3",
+                           "fr3_link0")) {}
 
-    std::ifstream file(file_path);
-    if (!file) {
-      throw std::runtime_error("Failed to open file: " + file_path);
-    }
-
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-
-    return buffer.str();
-  }
+  virtual ~FrankaRobotStateMultiArmTestFriend() = default;
 };
 
 class FrankaRobotStateTest : public ::testing::Test {
@@ -84,4 +124,26 @@ class FrankaRobotStateTest : public ::testing::Test {
   std::unique_ptr<FrankaRobotStateTestFriend> franka_state_friend;
 
   std::vector<std::string> full_interface_names;
+};
+
+class FrankaRobotStateMultiArmTest : public ::testing::Test {
+ public:
+  void SetUp();
+
+  void TearDown();
+
+ protected:
+  const size_t size = 1;
+  const std::string robot_name = "fr3";
+  const std::string franka_state_interface_name = "robot_state";
+  franka::RobotState robot_state;
+  realtime_tools::RealtimeThreadSafeBox<franka::RobotState> robot_state_box;
+  realtime_tools::RealtimeThreadSafeBox<franka::RobotState>* robot_state_box_ptr = &robot_state_box;
+
+  // Distinct per joint, so a value that came from the wrong libfranka array is visible.
+  std::array<double, 7> joint_angles = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
+  std::array<double, 7> desired_joint_angles = {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7};
+  franka_msgs::msg::FrankaRobotState franka_robot_state_msg;
+
+  std::unique_ptr<FrankaRobotStateMultiArmTestFriend> franka_state_friend;
 };


### PR DESCRIPTION
Fixes the `FrankaRobotState` joint-array defect reported in #241.

Closes #241

## The problem

`FrankaRobotState::set_joints_from_urdf()` collects **every** revolute joint in the controller
manager's global `robot_description`. Every `sensor_msgs/JointState` array inside
`FrankaRobotState` is then sized and named from that list, while still being *filled* from
libfranka's seven-element per-arm arrays:

```cpp
const auto n_joints = message.measured_joint_state.position.size();   // 15 on a duo description
std::copy_n(robot_state_.q.cbegin(), n_joints, message.measured_joint_state.position.begin());
```

With more than seven revolute joints in the description, each of those nine `copy_n` calls reads
past the end of a `std::array<double, 7>` into the next member of the same `franka::RobotState`,
so the trailing entries carry a different physical quantity than their joint name says. And
because every instance writes *its own* arm's data at indices 0..6 regardless of what the names
at 0..6 are, each broadcaster labels its own arm's measurements with the alphabetically-first
arm's joint names.

On a seven-revolute-joint robot `n_joints == 7`, the copy is in bounds and everything is correct.
#241 has the full mechanism, the element-by-element mapping and a self-contained reproduction.

## Verified still present at the ref this branches from

Branched from `jazzy` at **`ee1b79b77e473751852b4f884d1f7ce86041dfff`** ("chore: bump release for
3.5.2"), which was `jazzy` HEAD when this was opened. Re-checked at that exact ref rather than
relying on the earlier read:

- `set_joints_from_urdf()` at `franka_semantic_components/src/franka_robot_state.cpp:151-158` is
  unfiltered.
- The resizes at `:202-216` and the names at `:163-170` both come from that list.
- The `copy_n` fill at `:308-323` still uses the destination size as the copy length.
- `franka_semantic_components/test/robot_description_test.txt` still has exactly seven revolute
  joints, so nothing in the existing suite exercises the case.

The behavioural check is in this PR: the three new tests fail on the parent commit and pass with
the fix. See *What I ran* below.

## The fix

`set_joints_from_urdf()` now resolves **this** component's seven joints by name instead of taking
every revolute joint in the description:

```cpp
joint_names.reserve(kJointCount);
for (size_t i = 0; i < kJointCount; ++i) {
  const auto joint_name = robot_name_ + "_joint" + std::to_string(i + 1);
  if (model_->joints_.find(joint_name) == model_->joints_.end()) {
    throw std::runtime_error("Joint '" + joint_name + "' not found in URDF.");
  }
  joint_names.push_back(joint_name);
}
```

That is the same pattern `initialize_robot_state_msg()` already uses to resolve the accelerometer
frames a few lines further down. It fixes the size, the fill and the labels together: the arrays
are seven long, `copy_n` is in bounds, and the names are this arm's own, in joint order.

#241 left two things open as your call; here is what this picks and why, both easy to change:

- **Joint order, not alphabetical.** The old order came from `urdf::ModelInterface::joints_` being
  a `std::map`, i.e. sorted by joint name — which is why `left_*` happened to land at 0..6 and
  `right_*` at 7..13. Joint order matches the order libfranka reports the values in, which is what
  the arrays are indexed by.
- **Throw rather than warn** when the description does not contain this arm. A description that
  cannot be matched to the arm is a configuration error, and this is already how a missing
  accelerometer frame is treated in the same file.

### Behaviour change worth reviewing

This adds exactly one new requirement on the `robot_description`: that it contain
`<robot_name>_joint7`. Joints 1..6 are **already** required — the accelerometer loop in
`initialize_robot_state_msg()` (`:220-224`) throws if `<robot_name>_joint1..6` are missing, and
that runs at `on_configure()`. So any configuration that would newly fail here is one that
already fails today, one joint later.

For a single-arm FR3 the published message is unchanged: the same seven names, the same seven
values, in the same order.

### Not `std::min(n_joints, 7)`

Capping the copy length silences the out-of-bounds read but leaves the arrays fifteen long, with
eight trailing zeros published under *other arms'* joint names. Indexing by name is still wrong,
the crossed-arm labelling is untouched, and it is arguably worse than the current state because
it now looks safe. Please don't simplify the patch back to that.

## The test

`franka_robot_state_test` gains a `FrankaRobotStateMultiArmTest` fixture. It splices a second
seven-joint revolute chain into the existing `robot_description_test.txt` at runtime — no new data
file, and the arm under test keeps its accelerometer frames — so the component is built from a
description with fourteen revolute joints. It asserts:

- every one of the twelve resized arrays is `7u` long — the constant, not `name.size()`;
- all four name lists are exactly `fr3_joint1..7`, so the labels belong to this arm;
- `measured_joint_state.position` is `q` and `desired_joint_state.position` is `q_d`, with
  per-joint-distinct sentinels, so a value pulled from the wrong libfranka array is visible.

There is also a small standalone test that a description not containing this arm throws.

The existing `givenInitializedRobotStateMsg_thenCorrectlySizedDynamicVectors` compares each
array's size against `measured_joint_state.name.size()`. Both sides grow together, so it holds at
any width — that is the defect's own shape. Asserting the constant `7u` is what pins it.

One existing test needed updating: `test_franka_robot_state_broadcaster` built its mock from
`ros2_control_test_assets::minimal_robot_urdf`, which contains no joint named after the arm. It
now builds a minimal seven-joint description for the arm it names. That change is independent of
the fix — the test passes with it both before and after.

## Severity, as honestly as I can put it

Restating from #241 so this PR does not read as more urgent than it is:

- **It cannot crash and cannot leak unrelated memory.** Every over-read's byte range stays inside
  the enclosing `franka::RobotState` (`sizeof == 3296`); at fifteen joints all nine are inside.
  It is a data-correctness bug, not a memory-safety incident.
- **It only affects `robot_description`s with more than seven revolute joints.** Single-arm FR3 is
  entirely unaffected.
- **Your own duo bringups don't start this broadcaster** — `fr3_duo.launch.py:54-55` and
  `mobile_fr3_duo.launch.py:60-61` say it is not supported for multi-arm configurations. So this
  is not breaking a shipped configuration; we hit it by starting the broadcaster per arm on a
  mobile-FR3-Duo-derived robot.

What makes it worth fixing rather than documenting is that it is silent — no throw, no warning,
plausible-looking numbers — and the values involved are joint positions and torques.

`humble` is not affected by the out-of-bounds read (it bounds the copy by the source), though it
does still take its names from the global list. This PR targets `jazzy` only.

## What I ran

Built and tested in this repo's own container (`docker build -f Dockerfile .`, `ros:jazzy-ros-base`),
against libfranka 0.20.5 and the `ros2_control` pin from `dependency.repos`, with the
`manage_overruns` patch applied:

```
colcon build --packages-up-to franka_semantic_components franka_robot_state_broadcaster \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCHECK_TIDY=ON -DBUILD_TESTING=ON
colcon test --packages-select franka_semantic_components franka_robot_state_broadcaster
```

- **On this branch:** every test in both packages passes — 13 checks in
  `franka_semantic_components` (including `clang_tidy` with `CHECK_TIDY=ON`) and 9 in
  `franka_robot_state_broadcaster`. One pre-existing exception: `clang_format` flags
  `src/translation_utils.hpp:66` (`template<typename T>` → `template <typename T>`) under
  clang-format 18.1.3. That file is not touched by this PR and the divergence is there on
  `ee1b79b7` as well, so I left it alone rather than mix an unrelated reformat in. Every file this
  PR does change reports "No code style divergence".

- **With the two source files reverted to `ee1b79b7`, keeping the new tests**, on the same build:
  the three new tests fail and the ten pre-existing ones still pass. That is the defect, at the
  ref this branches from:

  ```
  Expected equality of these values:
    franka_robot_state_msg.measured_joint_state.name
      Which is: { "fr3_joint1", ..., "fr3_joint7",
                  "second_fr3_joint1", ..., "second_fr3_joint7" }
    expected_names
      Which is: { "fr3_joint1", ..., "fr3_joint7" }

  Value of: joint_angles
  Expected: has 14 elements where ...
    Actual: { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7 }, which has 7 elements
  ```

**What I did not run.** Nothing on hardware — I did not have an FR3 available for this, so
`test_hardware` and `run_hardware_tests.sh` were not run, and I have not seen the fixed
broadcaster publish on a real robot. I also did not build the whole workspace: only these two
packages and their dependencies, importing libfranka, franka_description and ros2_control rather
than all of `dependency.repos`. Your CI covers both of those gaps.

## Conventions

- Rebased on `jazzy` at `ee1b79b7`; commit is `git commit -s` signed off per `CONTRIBUTING.md`,
  conventional-commit subject.
- `CHANGELOG.rst` gains an `UNRELEASED` section with one `fix:` entry for this branch, per
  `.github/skills/audit-docs/SKILL.md`. There was no `UNRELEASED` section to add to; happy to drop
  or reword it if you would rather it landed differently.
- No public API or message-definition change.

Happy to reshape any of this — the naming-convention assumption in particular is the part where
you know things I don't.
